### PR TITLE
[FEAT] 리액션으로 국밥 주는 기능 추가

### DIFF
--- a/src/bot.ts
+++ b/src/bot.ts
@@ -2,7 +2,7 @@ import config from './config';
 import BurritoStore from './store/BurritoStore';
 import LocalStore from './store/LocalStore';
 import { parseMessage } from './lib/parseMessage';
-import { validBotMention, validMessage } from './lib/validator';
+import { validBotMention, validMessage, validReaction } from './lib/validator';
 import Rtm from './slack/Rtm';
 import Wbc from './slack/Wbc';
 
@@ -101,6 +101,19 @@ const start = () => {
             }
         }
     });
+
+    Rtm.on('slackReaction', async (event: any) => {
+        if (validReaction(event)) {
+            const originalContent = await Wbc.fetchReactedMessage(event.item.channel, event.item.ts);
+            const result = parseMessage(originalContent, emojis);
+            if (result) {
+                const { giver, updates } = result;
+                if (updates.length) {
+                    await handleBurritos(giver, updates);
+                }
+            }
+        }
+    })
 };
 
 export {

--- a/src/lib/validator.ts
+++ b/src/lib/validator.ts
@@ -62,6 +62,17 @@ function validMessage(message: any, emojis: any, allBots: any): boolean {
     return true;
 }
 
+function validReaction(reaction: any): boolean {
+    // We don't want reactions on content other than messages
+    if (reaction.item.type != 'message') return false;
+
+    // If the reaction doesn't have sufficeint info it cannot be processed
+    if (reaction.item.channel === undefined) return false;
+    if (reaction.item.ts === undefined) return false;
+
+    return true;
+}
+
 function validBotMention(message: any, botUserID: any) {
     if ((message.text.match(`<@${botUserID}>`)) && (message.text.match('stats'))) {
         return true;
@@ -72,6 +83,7 @@ function validBotMention(message: any, botUserID: any) {
 export {
     validBotMention,
     validMessage,
+    validReaction,
     selfMention,
     sentFromBot,
     sentToBot,

--- a/src/slack/Rtm.ts
+++ b/src/slack/Rtm.ts
@@ -3,8 +3,10 @@ import { EventEmitter } from 'events';
 
 interface SlackEvent {
     type: string;
-    text: string;
     user: string;
+    text?: string;
+    reaction?: string;
+    item_user?: string;
     client_msg_id?: string;
     suppress_notification?: boolean;
     team?: string;
@@ -12,6 +14,13 @@ interface SlackEvent {
     event_ts?: string;
     ts?: string;
     subtype?: string;
+    item?: SlackItem;
+}
+
+interface SlackItem {
+    type: string;
+    channel?: string;
+    ts?: string;
 }
 
 class Rtm extends EventEmitter {
@@ -23,7 +32,7 @@ class Rtm extends EventEmitter {
     }
 
     listener(): void {
-        log.info('Listening on slack messages');
+        log.info('Listening on slack messages and reactions');
         this.rtm.on('message', (event: SlackEvent) => {
             if ((!!event.subtype) && (event.subtype === 'channel_join')) {
                 log.info('Joined channel', event.channel);
@@ -32,6 +41,11 @@ class Rtm extends EventEmitter {
                 this.emit('slackMessage', event);
             }
         });
+        this.rtm.on('reaction_added', (event: SlackEvent) => {
+            if (event.type === 'reaction_added') {
+                this.emit('slackReaction', event);
+            }
+        })
     }
 }
 

--- a/src/slack/Wbc.ts
+++ b/src/slack/Wbc.ts
@@ -45,6 +45,18 @@ class Wbc {
             log.info(`Notified user ${username}`);
         }
     }
+
+    async fetchReactedMessage(channelId: string, ts: number) {
+        log.info('Fetching reacted message via wbc');
+        const res = await this.wbc.conversations.history({
+            channel: channelId,
+            latest: ts,
+            inclusive: true,
+            limit: 1,
+        });
+
+        return res.messages[0];
+    }
 }
 
 export default new Wbc();


### PR DESCRIPTION
- 제곧내
- 리액션을 삭제할 경우 줬던 국밥을 뺏는 것은 구현하지 않았습니다
- 테스트도 추가하진 않았는데 나중에 기회가 된다면 추가하겠습니다