### PR TITLE
[FIX] 이모지에 정규표현식으로 처리 안되는 문제 해결

### DIFF
--- a/src/lib/parseMessage.ts
+++ b/src/lib/parseMessage.ts
@@ -80,7 +80,7 @@ function parseReactedMessage(reaction, reactedMsg, emojis) {
     users.push(reaction.item_user);
   }
 
-  const type = emojis.filter((e: any) => reaction.reaction.match(`${e.emoji}`))[0].type;
+  const type = emojis.filter((e: any) => e.emoji == `:${reaction.reaction}:`)[0].type;
 
   // Give each user a update
   users.forEach((u) => updates.push({ username: u, type: type }));

--- a/src/lib/validator.ts
+++ b/src/lib/validator.ts
@@ -70,7 +70,7 @@ function validReaction(reaction: any, emojis: any): boolean {
   if (reaction.item.channel === undefined) return false;
   if (reaction.item_user === undefined) return false;
   if (reaction.item.ts === undefined) return false;
-  return emojis.filter((e) => reaction.reaction.match(`${e.emoji}`)).length > 0;
+  return emojis.filter((e) => e.emoji == `:${reaction.reaction}:`).length > 0;
 }
 
 function validBotMention(message: any, botUserID: any) {


### PR DESCRIPTION
이모지 + 기호가 섞여있으면 정규표현식이 의도와 다르게 작동할 수 있습니다
이모지의 경우 어차피 한번에 하나밖에 달 수 없기 때문에 그냥 앞 뒤로 `:` 를 붙여줘서 `==` 체크를 했습니다