### PR TITLE
[FIX] 여러명을 멘션하고 덕을 여러개 주는 경우 처리

### DIFF
--- a/src/bot.ts
+++ b/src/bot.ts
@@ -81,10 +81,13 @@ const handleBurritos = async (giver: string, channel: string, updates: Updates[]
 
   const givenDucks = await BurritoStore.givenBurritosToday(giver, 'from');
   const leftOverDucks = dailyCap - givenDucks;
-  const receivers = updates.map((it) => it.username);
+  const receivers = [...new Set(updates.map((it) => it.username))];
+  const eachGivenDucks = Math.ceil(updates.length / receivers.length);
   notifyUser(
     giver,
-    `${receivers.map((it) => `<@${it}>`).join(" ")}에게 ${updates.length}개의 :duck:을 주었습니다. 오늘 ${leftOverDucks}개의 :duck:을 더 줄 수 있습니다.`,
+    `${receivers
+      .map((it) => `<@${it}>`)
+      .join(' ')}에게 ${eachGivenDucks}개의 :duck:을 주었습니다. 오늘 ${leftOverDucks}개의 :duck:을 더 줄 수 있습니다.`,
   );
   receivers.forEach((receiver) => {
     notifyUser(receiver, `<@${giver}>님이 <#${channel}>에서 1개의 :duck:을 주었습니다.`);


### PR DESCRIPTION
- 기존 무조건 1 상수로 박아두던 것을 여러 유저를 멘션하면서 여러 덕을 줘도 준 갯수를 제대로 계산하도록 수정합니다