### PR TITLE
[FIX] 덕 지급 잘못되는 이슈 수정

### DIFF
--- a/src/lib/parseMessage.ts
+++ b/src/lib/parseMessage.ts
@@ -76,9 +76,10 @@ function parseReactedMessage(reaction, reactedMsg, emojis) {
   // Get usernames from reacted slack message
   const users: string[] = parseUsernames(reactedMsg.text);
 
+  const sender = reactedMsg.user ?? reaction.item_user
   // If no one is mentioned on the original slack message, the sender receives ducks
-  if (!users.length) {
-    users.push(reactedMsg.user);
+  if (!users.length && !sender) {
+    users.push(sender);
   }
 
   // Filter self reaction

--- a/src/lib/parseMessage.ts
+++ b/src/lib/parseMessage.ts
@@ -76,13 +76,13 @@ function parseReactedMessage(reaction, reactedMsg, emojis) {
   // Get usernames from reacted slack message
   const users: string[] = parseUsernames(reactedMsg.text);
 
+  // If no one is mentioned on the original slack message, the sender receives ducks
+  if (!users.length) {
+    users.push(reactedMsg.user);
+  }
+
   // Filter self reaction
   users.filter((u) => u !== reaction.user);
-
-  // If no one is mentioned on the original slack message and the sender is not the reactor, the sender receives ducks
-  if (!users.length && reaction.item_user != reaction.user) {
-    users.push(reaction.item_user);
-  }
 
   const type = emojis.filter((e: any) => e.emoji == `:${reaction.reaction}:`)[0].type;
 


### PR DESCRIPTION
원래 코드를 잘 이해하지 못해서 제스타일로 바꿔버림

1. 기본적으로 메세지에 언급된 사람들이 대상이 된다
2. 언급된 사람이 없으면 메세지를 쓴 사람이 대상이다
3. 대상들 중에서 리액션을 단 유저가 아닌 사람만 받는다