### PR TITLE
[FIX] 리액션 달린 메세지 잘못 가져오는 이슈 수정

### DIFF
--- a/src/lib/parseMessage.ts
+++ b/src/lib/parseMessage.ts
@@ -87,11 +87,6 @@ function parseReactedMessage(reaction, reactedMsg, emojis) {
   // Filter self reaction
   users.filter((u) => u !== reaction.user);
 
-  log.info("reactedMsg: " + reactedMsg.text)
-  log.info("users: " + users.join(','))
-  log.info("sender: " + sender)
-  log.info("final users: " + users.join(','))
-
   const type = emojis.filter((e: any) => e.emoji == `:${reaction.reaction}:`)[0].type;
 
   // Give each user a update

--- a/src/slack/Rtm.ts
+++ b/src/slack/Rtm.ts
@@ -41,7 +41,8 @@ class Rtm extends EventEmitter {
         this.emit('slackMessage', event);
       }
     });
-    this.rtm.on('reaction_added', (event: SlackEvent) => {
+    this.rtm.on('reaction_added', (event: any) => {
+      log.info(event)
       if (event.type === 'reaction_added') {
         this.emit('slackReaction', event);
       }

--- a/src/slack/Rtm.ts
+++ b/src/slack/Rtm.ts
@@ -41,8 +41,7 @@ class Rtm extends EventEmitter {
         this.emit('slackMessage', event);
       }
     });
-    this.rtm.on('reaction_added', (event: any) => {
-      log.info(event)
+    this.rtm.on('reaction_added', (event: SlackEvent) => {
       if (event.type === 'reaction_added') {
         this.emit('slackReaction', event);
       }

--- a/src/slack/Wbc.ts
+++ b/src/slack/Wbc.ts
@@ -88,6 +88,8 @@ class Wbc {
       limit: 1,
     });
 
+    log.info(res)
+
     return res.messages[0];
   }
 }

--- a/src/slack/Wbc.ts
+++ b/src/slack/Wbc.ts
@@ -90,6 +90,7 @@ class Wbc {
 
     const res2 = await this.wbc.conversations.replies({
       channel: channelId,
+      ts: ts,
       latest: ts,
       inclusive: true,
       limit: 1,

--- a/src/slack/Wbc.ts
+++ b/src/slack/Wbc.ts
@@ -88,7 +88,15 @@ class Wbc {
       limit: 1,
     });
 
+    const res2 = await this.wbc.conversations.replies({
+      channel: channelId,
+      latest: ts,
+      inclusive: true,
+      limit: 1,
+    });
+
     log.info(res)
+    log.info(res2)
 
     return res.messages[0];
   }

--- a/src/slack/Wbc.ts
+++ b/src/slack/Wbc.ts
@@ -81,23 +81,14 @@ class Wbc {
 
   async fetchReactedMessage(channelId: string, ts: number) {
     log.info('Fetching reacted message via wbc');
-    const res = await this.wbc.conversations.history({
-      channel: channelId,
-      latest: ts,
-      inclusive: true,
-      limit: 1,
-    });
 
-    const res2 = await this.wbc.conversations.replies({
+    const res = await this.wbc.conversations.replies({
       channel: channelId,
       ts: ts,
       latest: ts,
       inclusive: true,
       limit: 1,
     });
-
-    log.info(res)
-    log.info(res2)
 
     return res.messages[0];
   }


### PR DESCRIPTION
conversation.history는 그냥 채널에 달린 메세지를 가져오고, 쓰레드는 가져오지 못하는 것 같다.
replies로 하니까 그냥 메세지도 잘 가져오고 쓰레드도 잘 가져오는 것 같음
```
{
0|npm  |   ok: true,
0|npm  |   messages: [
0|npm  |     {
0|npm  |       user: 'U03PS90M8QM',
0|npm  |       type: 'message',
0|npm  |       ts: '1710159648.067449',
0|npm  |       client_msg_id: '226c0ff0-2491-4599-886f-3fb745221040',
0|npm  |       text: 'dddd',
0|npm  |       team: 'T02ULP71W',
0|npm  |       thread_ts: '1703066553.577099',
0|npm  |       parent_user_id: 'U03PS90M8QM',
0|npm  |       blocks: [Array],
0|npm  |       reactions: [Array]
0|npm  |     }
0|npm  |   ],
0|npm  |   has_more: false,
0|npm  |   response_metadata: {
0|npm  |     scopes: [ 'identify', 'read', 'post', 'client', 'apps' ],
0|npm  |     acceptedScopes: [
0|npm  |       'channels:history',
0|npm  |       'groups:history',
0|npm  |       'mpim:history',
0|npm  |       'im:history',
0|npm  |       'read'
0|npm  |     ]
0|npm  |   }
0|npm  | }
```

[레퍼런스](https://api.slack.com/methods/conversations.replies)
레퍼런스에는 `To use conversations.replies with public or private channel threads, use a [user token](https://api.slack.com/docs/token-types#user) with [channels:history](https://api.slack.com/scopes/channels:history) or [groups:history](https://api.slack.com/scopes/groups:history) scopes.`
라고 써있지만, 막상 해보니 private 채널도 잘 가져오는 것 같다