### PR TITLE
[FIX] Private 여부만 체크하기

### DIFF
--- a/src/slack/Wbc.ts
+++ b/src/slack/Wbc.ts
@@ -111,7 +111,7 @@ class Wbc {
       channel: channelId,
     });
 
-    return res.channel.is_private;
+    return res.channel.is_group || res.channel.is_im || res.channel.is_private;
   }
 }
 

--- a/src/slack/Wbc.ts
+++ b/src/slack/Wbc.ts
@@ -111,7 +111,7 @@ class Wbc {
       channel: channelId,
     });
 
-    return res.channel.is_channel && res.channel.is_private;
+    return res.channel.is_private;
   }
 }
 


### PR DESCRIPTION
- is_group (특정 시점 이전에 만들어진 private 채널) 이거나 is_im (DM 채널) 인경우에도 `is_private` 은 항상 true 일거라고 하더니 실제로 로그 찍어보니 `is_private` 필드가 아예 없을 때가 있어서 모두 필터링합니다
- 예시 로그
```
Channel Info: {"id":"D057B7XCXC4","created":1683789018,"is_archived":false,"is_im":true,"is_org_shared":false,"context_team_id":"T02ULP71W","updated":1683789018647,"user":"U03RRCWA403","last_read":"0000000000.000000","latest":{"user":"U03RRCWA403","type":"message","ts":"1717391033.809039","client_msg_id":"279f48ae-6620-4c23-8a4b-43e10e63e3ea","text":"<@U03PS90M8QM> :duck:  뭐함","team":"T02ULP71W","blocks":[{"type":"rich_text","block_id":"U4lWt","elements":[{"type":"rich_text_section","elements":[{"type":"user","user_id":"U03PS90M8QM"},{"type":"text","text":" "},{"type":"emoji","name":"duck","unicode":"1f986"},{"type":"text","text":"  뭐함"}]}]}]},"unread_count":336,"unread_count_display":336,"is_open":true,"priority":0}
```
![image](https://github.com/VCNC/heyduck/assets/43549670/aa4f569b-e57e-4e2e-9696-593d1085bffe)
