### PR TITLE
[FEAT] 셀프덕만 줄 시 안내메세지를 전송합니다.

### DIFF
--- a/src/bot.ts
+++ b/src/bot.ts
@@ -50,11 +50,12 @@ const notifyUser = (user: string, message: string, messageBlock?: Object[]) => {
 };
 
 const handleBurritos = async (giver: string, channel: string, duckedMessage: string, duckedMessageLink: string, updates: Updates[]) => {
-  log.info(updates)
   const giverIdx = updates.findIndex( (update) => update.username === giver )
   if (giverIdx > -1) {
     updates.splice(giverIdx, 1);
   }
+
+  log.info(updates)
 
   if (updates.length === 0) {
     notifyUser(giver, `나 자신에게 :duck:을 줄 수 없습니다. 메세지를 전송한 사람에게 주고싶다면 새로 태그하고 주는 것은 어떨까요?`, [

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -51,6 +51,23 @@ const notifyUser = (user: string, message: string, messageBlock?: Object[]) => {
 
 const handleBurritos = async (giver: string, channel: string, duckedMessage: string, duckedMessageLink: string, updates: Updates[]) => {
   log.info(updates)
+  const giverIdx = updates.findIndex( (update) => update.username === giver )
+  if (giverIdx > -1) {
+    updates.splice(giverIdx, 1);
+  }
+
+  if (updates.length === 0) {
+    notifyUser(giver, `나 자신에게 :duck:을 줄 수 없습니다. 메세지를 전송한 사람에게 주고싶다면 새로 태그하고 주는 것은 어떨까요?`, [
+      {
+        type: 'section',
+        text: {
+          type: 'mrkdwn',
+          text: `<${duckedMessageLink}|내가 덕 주려고 했던 메세지>`,
+        },
+      },
+    ]);
+  }
+
   if (!enableDecrement) {
     const burritos = await BurritoStore.givenBurritosToday(giver, 'from');
     const diff = dailyCap - burritos;

--- a/src/lib/parseMessage.ts
+++ b/src/lib/parseMessage.ts
@@ -84,18 +84,10 @@ function parseReactedMessage(reaction, reactedMsg, emojis) {
     users.push(sender);
   }
 
-  // Filter self reaction
-  const filteredUsers = users.filter((u) => u !== reaction.user);
-
-  log.info('reactedMsg: ' + reactedMsg.text);
-  log.info('users: ' + users.join(','));
-  log.info('sender: ' + sender);
-  log.info('final users: ' + filteredUsers.join(','));
-
   const type = emojis.filter((e: any) => e.emoji == `:${reaction.reaction}:`)[0].type;
 
   // Give each user a update
-  filteredUsers.forEach((u) => updates.push({ username: u, type: type }));
+  users.forEach((u) => updates.push({ username: u, type: type }));
 
   return {
     updates,


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/07f10ee7-bbfc-4bbd-a4dc-0bbea834eadd)
![image](https://github.com/user-attachments/assets/8306f867-156f-4a9b-8f80-eb8c8e3c2494)

알다시피 덕을 주는 정책때문에, 특정 사람에게 덕을 주려고 했다가 잘못 주는 경우가 있습니다
여러명이 태그된 상태에서 자신을 제외한 사람들에게 주는건 솔직히 의도일 수도 있어서 따로 안내를 해주지는 않고,
한명한테만 주는데 그 대상이 나인 경우에만 안내 메세지를 주면 사람들이 실수하는 경우가 줄어들지 않을까 하는 기대